### PR TITLE
location="inx"

### DIFF
--- a/svgPianoScale.inx
+++ b/svgPianoScale.inx
@@ -2,7 +2,7 @@
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
   <name>Piano scale</name>
   <id>piroxiljin.Pianoscale</id>
-  <dependency type="executable" location="extensions">svgPianoScale.py</dependency>
+  <dependency type="executable" location="inx">svgPianoScale.py</dependency>
   
   <param name="firstNote" type="string" gui-text="First note">C1</param>
   <param name="lastNote"  type="string" gui-text="Last note">B2</param>


### PR DESCRIPTION
This small change allows installing this plugin by just putting its own folder into the Inkscape's folder (e.g. `~/.config/inkscape/extension/music-scale-generator/`).

I don't know if it has any other side-effect, I know it worked for me. And makes me wish all plugins could be installed in their own folders.